### PR TITLE
Add springdoc dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,11 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'springdoc-openapi-starter-webmvc-ui:2.0.4'
+    providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## Summary
- add `springdoc-openapi-starter-webmvc-ui:2.0.4` dependency

## Testing
- `./gradlew test` *(fails: No route to host)*